### PR TITLE
fix id substring syntax highlighting

### DIFF
--- a/syntax/yesod.vim
+++ b/syntax/yesod.vim
@@ -21,7 +21,7 @@ syn keyword yesodModelsKeywords json deriving
 syn keyword yesodModelsTypes Text ByteString Int64 Double Rational Bool Day
 syn keyword yesodModelsTypes TimeOfDay UTCTime Maybe Int Integer String Textarea
 syn keyword yesodModelsTypes Typeable Generic Eq Show Read Enum
-syn match yesodModelsTypes "\C\v[A-Z]+[a-zA-Z]*Id"
+syn match yesodModelsTypes "\C\v\zs[A-Z]+[a-zA-Z]*Id\ze\s+"
 syn match yesodModelsEntity "\C\v^[A-Z]\S*"
 syn match yesodModelsField "\C\v^\s+\zs[a-z][a-zA-Z]\S*\ze"
 syn match yesodModelsFieldUnique "\C\v^\s+\zsUnique[A-Z]{1}[a-z]+[a-zA-Z]\S*\ze"

--- a/syntax/yesod.vim
+++ b/syntax/yesod.vim
@@ -21,7 +21,7 @@ syn keyword yesodModelsKeywords json deriving
 syn keyword yesodModelsTypes Text ByteString Int64 Double Rational Bool Day
 syn keyword yesodModelsTypes TimeOfDay UTCTime Maybe Int Integer String Textarea
 syn keyword yesodModelsTypes Typeable Generic Eq Show Read Enum
-syn match yesodModelsTypes "\C\v\zs[A-Z]+[a-zA-Z]*Id\ze\s+"
+syn match yesodModelsTypes "\C\v\zs[A-Z]+[a-zA-Z]*Id\ze(\s+|$)"
 syn match yesodModelsEntity "\C\v^[A-Z]\S*"
 syn match yesodModelsField "\C\v^\s+\zs[a-z][a-zA-Z]\S*\ze"
 syn match yesodModelsFieldUnique "\C\v^\s+\zsUnique[A-Z]{1}[a-z]+[a-zA-Z]\S*\ze"


### PR DESCRIPTION
If you have a substring with Id in it in a yesod route resource can match the prefix as a yesod type causing weird syntax highlighting:

Before:
![image](https://user-images.githubusercontent.com/13813526/174435771-168adf08-637b-4b92-bf96-0b0ed71180f5.png)

After:
![image](https://user-images.githubusercontent.com/13813526/174435670-2c2293fc-4639-40ae-b89d-04e022cd48b5.png)

(Thanks for the plugin btw!)