### PR TITLE
Set the 'comments' setting on yesod files

### DIFF
--- a/ftplugin/yesod.vim
+++ b/ftplugin/yesod.vim
@@ -21,6 +21,7 @@ endif
 command! YesodAddHandler execute "call yesod#AddHandler()"
 command! YesodOpenHandler execute "call yesod#OpenHandler()"
 setlocal commentstring=--\ %s
+setlocal! comments=:--
 
 
 function! yesod#OpenHandler()


### PR DESCRIPTION
This makes tcomment.vim work properly, but more to the point, it fixes various misbehaviour around formatoptions=c (autoformat comments; see :h fo-table).

To test it, you can do this:

`:setlocal fo+=rc`

```
-- blah<hit enter>
SomeModel
  blah Int
```

The expected result is:

```
-- blah
-- |       <- cursor is here
SomeModel
  blah Int
```